### PR TITLE
Add browser property

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "markdown.markdownItPlugins": true
   },
   "main": "./extension.js",
+  "browser": "./extension.js",
   "dependencies": {
     "markdown-it-pandoc": "^2.1.0",
     "markdown-it-task-lists": "^2.0.0",


### PR DESCRIPTION
Nowadays, VSCode can be used in the web browser as you might know.
To use this plugin in vscode.dev and github.dev, we need to publish this extension as a _web extension_. The good news is that it is enough to add browser property in package.json. I am looking forward to using this plugin in vscode.dev.